### PR TITLE
Merge cupy code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Geometric Phase Analysis enables the extraction of a _displacement field_ from a
 - Once the displacement field is known, it is also possible to perform unit cell averaging directly from the distorted image, creating low-noise or higher magnification (depending on the PSF of the instrument) images of the unit cell.
 - This unit cell average can be extended back to the full image to create a low noise version, or explore difference from mean unit cell.
 
+## Installation
+
+Installation is somewhat non-trivial, due to dependency on a [non-packaged implementation](https://github.com/TAdeJong/moisan2011) of the smooth + periodic decomposition. Furthermore, to use [CuPy](https://docs.cupy.dev/en/stable/install.html) acceleration, a NVIDIA graphics card and working CUDA installation are needed.
+
+First clone the repository. In the `pyGPA` folder, run the following:
+
+```bash
+$ pip install -e .
+$ pip install git+https://github.com/TAdeJong/moisan2011.git#egg=moisan2011
+```
+
+For CUDA acceleration, follow installation instructions of CuPy https://docs.cupy.dev/en/stable/install.html.
+
 ## Testing
 
 This project uses ``pytest`` and ``hypothesis`` to run tests. The test coverage is far from complete and can be extented though! To test:
@@ -27,9 +40,10 @@ Run the tests.
 
 ```bash
 $ pytest
-================ 4 passed in 5.58s ================
+========================== 20 passed in 42.28s ============================
 ```
 
+Note: The `cuGPA` tests will be skipped automatically if no working `CuPy` installation is detected.
 
 ## See also
 

--- a/pyGPA/cuGPA.py
+++ b/pyGPA/cuGPA.py
@@ -1,0 +1,158 @@
+"""Module with cupy versions, i.e. GPU accelerated versions
+of some geometric_phase_analysis functions."""
+
+import numpy as np
+import cupy as cp
+import cupyx.scipy.ndimage as cpndi
+
+from .mathtools import wrapToPi
+
+
+def cuGPA(image, kvec, sigma=22):
+    """Perform spatial lock-in on an image
+
+    GPU version of `optGPA()`.
+
+    Parameters
+    ----------
+    image : np.array
+        2D image input image
+    kvec : 2-tuple or array of float
+        components of the reference k-vector
+    sigma : float, default=22
+        standard deviation/ width of the Gaussian window
+
+    Returns
+    -------
+    res : np.array, dtype complex
+        Complex lock-in signal. Same shape as `image`.
+
+    Notes
+    -----
+    This function should be a prime candidate to speed up using cupy.
+    """
+    xx, yy = cp.ogrid[0:image.shape[0], 0:image.shape[1]]
+    multiplier = cp.exp(np.pi*2j * (xx*kvec[0] + yy*kvec[1]))
+    X = cp.fft.fft2(cp.asarray(image) * multiplier)
+    res = cp.fft.ifft2(cpndi.fourier_gaussian(X, sigma=sigma))
+    return res
+
+
+def wfr2_grad_opt(image, sigma, kx, ky, kw, kstep, grad=None):
+    """Optimized version of wfr2_grad.
+
+    In addition to returning the
+    used k-vector and lock-in signal, return the gradient of the lock-in
+    signal as well, for each pixel computed from the values of the surrounding pixels
+    of the GPA of the best k-vector. Slightly more accurate, determination of this gradient,
+    as boundary effects are mitigated.
+    """
+    xx, yy = cp.ogrid[0:image.shape[0],
+                      0:image.shape[1]]
+    c_image = cp.asarray(image)
+    g = {'w': cp.zeros(image.shape + (2,)),
+         'lockin': cp.zeros_like(c_image, dtype=np.complex128),
+         'grad': cp.zeros(image.shape + (2,)),
+         }
+    gaussian = cpndi.fourier_gaussian(cp.ones_like(c_image), sigma=sigma)
+    if grad == 'diff':
+        def grad_func(phase):
+            dbdx = cp.diff(phase, axis=0, append=np.nan)
+            dbdy = cp.diff(phase, axis=1, append=np.nan)
+            return dbdx, dbdy
+    elif grad is None:
+        def grad_func(phase):
+            return cp.gradient(phase)
+    else:
+        grad_func = grad
+    for wx in np.arange(kx-kw, kx+kw, kstep):
+        for wy in np.arange(ky-kw, ky+kw, kstep):
+            multiplier = cp.exp(np.pi*2j * (xx*wx + yy*wy))
+            X = cp.fft.fft2(c_image * multiplier)
+            X = X * gaussian
+            sf = cp.fft.ifft2(X)
+            t = cp.abs(sf) > cp.abs(g['lockin'])
+            g['lockin'] = cp.where(t, sf * cp.exp(-2j*np.pi*((wx-kx)*xx + (wy-ky)*yy)), g['lockin'])
+            g['w'] = cp.where(t[..., None], cp.array([wx, wy]), g['w'])
+
+            angle = -cp.angle(sf)
+            grad = grad_func(angle)
+            grad = cp.stack(grad, axis=-1)
+            # TODO: do outside forloop.
+            g['grad'] = cp.where(t[..., None], grad + 2*np.pi * cp.array([(wx-kx), (wy-ky)]), g['grad'])
+    for key in g.keys():
+        g[key] = g[key].get()
+    g['w'] = np.moveaxis(g['w'], -1, 0)
+    g['grad'] = wrapToPi(2 * g['grad']) / 2
+    return g
+
+
+def wfr2_grad_single(image, sigma, kx, ky, kw, kstep, grad=None):
+    """Optimized, single precision version of wfr2_grad.
+
+    Single precision might be faster on some hardware.
+    In addition to returning the
+    used k-vector and lock-in signal, return the gradient of the lock-in
+    signal as well, for each pixel computed from the values of the surrounding pixels
+    of the GPA of the best k-vector. Slightly more accurate, determination of this gradient,
+    as boundary effects are mitigated.
+    """
+    xx, yy = cp.ogrid[0:image.shape[0],
+                      0:image.shape[1]]
+    c_image = cp.asarray(image, dtype=np.float32)
+    g = {'lockin': cp.zeros_like(c_image, dtype=np.complex64),
+         'grad': cp.zeros(image.shape + (2,), dtype=np.float32),
+         }
+    gaussian = cpndi.fourier_gaussian(cp.ones_like(c_image, dtype=np.float32), sigma=sigma)
+    if grad == 'diff':
+        def grad_func(phase):
+            dbdx = cp.diff(phase, axis=0, append=np.nan)
+            dbdy = cp.diff(phase, axis=1, append=np.nan)
+            return dbdx, dbdy
+    elif grad is None:
+        def grad_func(phase):
+            return cp.gradient(phase)
+    else:
+        grad_func = grad
+    for wx in np.arange(kx-kw, kx+kw, kstep):
+        for wy in np.arange(ky-kw, ky+kw, kstep):
+            multiplier = cp.exp(np.pi*2j * (xx*wx + yy*wy))
+            X = cp.fft.fft2(c_image * multiplier)
+            X = X * gaussian
+            sf = cp.fft.ifft2(X)
+            t = cp.abs(sf) > cp.abs(g['lockin'])
+            angle = -cp.angle(sf)
+            grad = grad_func(angle)
+            grad = cp.stack(grad, axis=-1)
+            g['lockin'] = cp.where(t, sf * cp.exp(-2j*np.pi*((wx-kx)*xx + (wy-ky)*yy)), g['lockin'])
+            # TODO: do outside forloop.
+            g['grad'] = cp.where(t[..., None], grad + 2*np.pi * cp.array([(wx-kx), (wy-ky)]), g['grad'])
+    for key in g.keys():
+        g[key] = g[key].get()
+    g['grad'] = wrapToPi(2 * g['grad']) / 2
+    return g
+
+
+def cuwfr2_only_lockin(image, sigma, kvec, kw, kstep):
+    """Optimized version of wfr2 calculating only the lock-in signal.
+    Optimization in amount of computation done in each step by only
+    computing updated values.
+    """
+    kx, ky = kvec
+    xx, yy = cp.ogrid[0:image.shape[0],
+                      0:image.shape[1]]
+    c_image = cp.asarray(image)
+    g = cp.zeros_like(c_image, dtype=np.complex)
+    gaussian = cpndi.fourier_gaussian(cp.ones_like(c_image), sigma=sigma)
+    for wx in np.arange(kx-kw, kx+kw, kstep):
+        for wy in np.arange(ky-kw, ky+kw, kstep):
+            multiplier = cp.exp(np.pi*2j * (xx*wx + yy*wy))
+            X = cp.fft.fft2(c_image * multiplier)
+            X = X * gaussian
+            sf = cp.fft.ifft2(X)
+            t = cp.abs(sf) > cp.abs(g)
+            g = cp.where(t,
+                         sf * cp.exp(-2j*np.pi*((wx-kx)*xx + (wy-ky)*yy)),
+                         g)
+    g = g.get()
+    return g

--- a/pyGPA/geometric_phase_analysis.py
+++ b/pyGPA/geometric_phase_analysis.py
@@ -481,7 +481,7 @@ def extract_primary_ks(image, plot=False, threshold=0.7, pix_norm_range=(2, 200)
         fig, ax = plt.subplots(ncols=2, figsize=[12, 8])
         fftplot(smooth, d=NMPERPIXEL, ax=ax[0],
                 levels=[smooth.max()*threshold*0.8],
-                contour=False, pcolormesh=False)
+                contour=False, pcolormesh=False, origin='lower')
         ax[0].set_xlabel('k (periods / nm)')
         ax[0].set_ylabel('k (periods / nm)')
         ax[0].scatter(*(all_ks/NMPERPIXEL).T, color='red',

--- a/pyGPA/property_extract.py
+++ b/pyGPA/property_extract.py
@@ -680,7 +680,7 @@ def Kerelsky_plus(kvecs, nmperpixel=1., a_0=0.246,
             print(res2)
         if res2.cost < res.cost:
             res = res2
-    if res.success and (res.cost <= 0.1):
+    if res.success and (res.cost <= 0.3):
         params = res.x
     else:
         params = np.full(4, np.nan)

--- a/tests/test_cuGPA.py
+++ b/tests/test_cuGPA.py
@@ -11,7 +11,7 @@ import pyGPA.cuGPA as cuGPA
 
 try:
     import cupy
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     pytest.skip("skipping cupy tests as cupy could not be imported", allow_module_level=True)
     
 

--- a/tests/test_cuGPA.py
+++ b/tests/test_cuGPA.py
@@ -7,10 +7,9 @@ import pytest
 import latticegen
 
 import pyGPA.geometric_phase_analysis as GPA
-import pyGPA.cuGPA as cuGPA
-
 try:
     import cupy
+    import pyGPA.cuGPA as cuGPA
 except (ImportError, ModuleNotFoundError):
     pytest.skip("skipping cupy tests as cupy could not be imported", allow_module_level=True)
     

--- a/tests/test_cuGPA.py
+++ b/tests/test_cuGPA.py
@@ -1,0 +1,66 @@
+import numpy as np
+import scipy.ndimage as ndi
+from hypothesis import given, settings
+import hypothesis.strategies as st
+import pytest
+
+import latticegen
+
+import pyGPA.geometric_phase_analysis as GPA
+import pyGPA.cuGPA as cuGPA
+
+try:
+    import cupy
+except ImportError:
+    pytest.skip("skipping cupy tests as cupy could not be imported", allow_module_level=True)
+    
+
+
+@pytest.fixture(scope='module')
+def gaussiandeform(size=500):
+    S = size // 2
+    xp, yp = np.meshgrid(np.arange(-S, S), np.arange(-S, S), indexing='ij')
+    xshift = 0.5*xp*np.exp(-0.5*((xp/(2*S/8))**2 + 1.2*(yp/(2*S/6))**2))
+    return np.stack((xshift, np.zeros_like(xshift)), axis=0)
+
+
+
+
+@pytest.fixture(scope='module')
+def testset_gaussian(gaussiandeform):
+    r_k = 0.1
+    xi0 = 7.0
+    psi = 0.0
+    kappa = 1.001
+    order = 2
+    S = 500
+    original = latticegen.hexlattice_gen(r_k, xi0, order, size=S,
+                                         kappa=kappa, psi=psi).compute()
+    deformed = latticegen.hexlattice_gen(r_k, xi0, order, S, kappa=kappa, psi=psi,
+                                         shift=gaussiandeform
+                                         ).compute()
+    # TODO: fix numpy random seed in a way compatible with both new and old numpy random interface
+    noise = ndi.filters.gaussian_filter(5*np.random.normal(size=deformed.shape), sigma=0.5)
+    ori_ks = latticegen.generate_ks(r_k, xi0, kappa=kappa, psi=psi)[:-1]
+    return original, deformed, noise, ori_ks
+
+@pytest.mark.parametrize("wfr_func", [cuGPA.wfr2_grad_opt, cuGPA.wfr2_grad_single])
+def test_displacement_field(testset_gaussian, gaussiandeform, wfr_func):
+    original, deformed, noise, ori_ks = testset_gaussian
+    u = -GPA.extract_displacement_field(deformed + noise, ori_ks[:3], wfr_func=wfr_func)
+    assert u.shape == gaussiandeform.shape
+    print(np.abs(u - gaussiandeform)[:, 20:-20, 20:-20].max())
+    assert np.all(np.abs(u - gaussiandeform)[:, 20:-20, 20:-20] < 0.9)
+    u2 = -GPA.extract_displacement_field(deformed, ori_ks[:3], deconvolve=True)
+    assert u2.shape == gaussiandeform.shape
+    print(np.abs(u2 - gaussiandeform)[:, 20:-20, 20:-20].max())
+    assert np.all(np.abs(u2 - gaussiandeform)[:, 20:-20, 20:-20] < 0.05)
+
+
+def test_reconstruction(testset_gaussian, gaussiandeform):
+    original, deformed, noise, ori_ks = testset_gaussian
+    u_inv = GPA.invert_u_overlap(-gaussiandeform)
+    assert u_inv.shape == gaussiandeform.shape
+    reconstructed = GPA.undistort_image(deformed, gaussiandeform)
+    assert np.all(np.abs(reconstructed - original) / np.abs(original).max() < 0.02)
+    # Add optical flow if feeling fancy, but parameters are hard to optimize.


### PR DESCRIPTION
This adds some rudimentary support for GPU accelerated GPA functions in `pyGPA/cuGPA`, to enable processing of videos within reasonable computation time.
Tests of cuGPA are only executed when a working `CuPy` installation is found.

This brings the code up to the level used in https://github.com/TAdeJong/figures-imaging-moire-deformations for generation of the figures in the ArXiV paper.